### PR TITLE
🤙 Feature: Add the beyond build command in the docs with an example

### DIFF
--- a/beyond.json
+++ b/beyond.json
@@ -1,5 +1,5 @@
 {
-  "applications": "projects.json",
-  "bundles": {},
-  "libraries": []
+	"packages": "projects.json",
+	"bundles": {},
+	"libraries": []
 }

--- a/documentation/modules/contents/code/ts/index.tsx
+++ b/documentation/modules/contents/code/ts/index.tsx
@@ -6,14 +6,16 @@ import * as Contents from '@beyond/docs/contents/esp';
 import * as ContentsEn from '@beyond/docs/contents/en';
 import { useState, useEffect } from 'react';
 import { RightAside } from './views/right-aside';
-import '@beyond/docs/missing.widget';
-import '@beyond/docs/under-construction.widget';
+
+// TODO: For some reason this fails now... Maybe something changed? Beyond Maybe?
+// import '@beyond/docs/under-construction.widget';
+// import '@beyond/docs/missing.widget';
 
 export /*bundle*/ function ContentsPage({ contentId, component }) {
 	const { current: lang } = beyond.languages;
 	// const ComponentToShow = contents[contentId][lang];
 
-	const replace = (text) => text.replace(text[0], text[0].toUpperCase());
+	const replace = text => text.replace(text[0], text[0].toUpperCase());
 	const Components = lang === 'es' ? Contents : ContentsEn;
 	const name = contentId.split('-').map(replace).join('');
 	const [Component, setComponent] = useState(Components[name]);
@@ -37,15 +39,15 @@ export /*bundle*/ function ContentsPage({ contentId, component }) {
 		return () => Components.hmr.on('change', onChange);
 	}, []);
 
-	if (!Component) {
-		return (
-			<main className="page__main-container">
-				<section className="page__main-content">
-					<app-under-construction />
-				</section>
-			</main>
-		);
-	}
+	// if (!Component) {
+	// 	return (
+	// 		<main className="page__main-container">
+	// 			<section className="page__main-content">
+	// 				<app-under-construction />
+	// 			</section>
+	// 		</main>
+	// 	);
+	// }
 
 	const Content = Components[name];
 

--- a/documentation/modules/contents/languages/en/mdx/starting/cli.mdx
+++ b/documentation/modules/contents/languages/en/mdx/starting/cli.mdx
@@ -1,54 +1,90 @@
-import {
-	NextLinks,
-	Link,
-	ELink,
-	DocHeader,
-	Title,
-	Subtitle,
-	BeyondJS,
-} from '@beyond/docs/components/html';
+import { Link, DocHeader, Title, Subtitle, BeyondJS, NextLinks } from '@beyond/docs/components/html';
 import { Code } from '@beyond/docs/code';
 
-<DocHeader pretitle="Fundamentals" title="Cli Commands" />
+<DocHeader pretitle="Fundamentals" title="BeyondJS CLI: Comprehensive Command Guide" />
 
-BeyondJS provides the following list of commands for working from the console of your preference:
+## Introduction
 
-> It is recommended the use of git bash in a version greater than `5.1.16` or in its defect the bash provided by your favorite code editor, in this tutorial we use the bash provided by vscode. In this tutorial we used the bash provided by vscode (In case you don't have it configured, see <ELink href="https://stackoverflow.com/questions/65438333/how-to-add-git-bash-to-vscode">this link</ELink>).
+BeyondJS offers a robust set of command-line instructions designed to streamline your development process. This guide
+elaborates on the functionality, usage, and parameters that each command accepts. Understanding these commands is
+crucial for working efficiently with BeyondJS.
 
-<Title tag="h4" text="Run" />
+## Command Summary
 
-<Code>{`beyond run [--workspace port]`}</Code>
+<Title tag="h4" text="beyond run" />
 
-The `run` command initializes the <BeyondJS/> DevServer and enables connection with
-the <Link href="/workspace">BeyondJS Workspace</Link>, which facilitates the debugging and package
-management process. It is necessary to run it to start working with <BeyondJS/>.
+<Code>{`beyond run [--inspector port]`}</Code>
 
-##### Parametros:
+#### Description
 
--   --workspace: Optional. This parameter defines the websocket connection port so that
-    the <Link href='/workspace'>Workspace</Link> can obtain information about the packages available
-    on the DevServer. If
-    not passed, <BeyondJS /> will take the default port 4000.
+The `beyond run` command initializes the BeyondJS Development Server (DevServer) and establishes a connection with the
 
-<Title tag="h4" text="add package" />
+<Link href="/workspace"> BeyondJS Workspace</Link>. This integration simplifies debugging and package management
+operations, making it an essential command for starting your work with BeyondJS.
+
+#### Parameters
+
+-   `--inspector`: Optional. Specifies the WebSocket port for the <Link href="/workspace">Workspace</Link> to obtain
+    information about the available packages on the DevServer. If this parameter is omitted, the default port will
+    be 4000.
+
+<Title tag="h4" text="beyond add package" />
 
 <Code>{`beyond add package`}</Code>
 
-"The 'add package' command allows you to create a new package and add it to the DevServer.
-When executed, it opens an interactive console where you can define the package's features, such as:
+#### Description
 
--   Package type: you can choose from options such as web, backend, web-backend, node, express. For more information on the different project types, see the <Link href="/packages/create">Creating Packages</Link> section."
+The `beyond add package` command allows you to create a new package and integrate it into the DevServer. Upon execution,
+an interactive console is activated, inviting you to specify various package attributes.
 
-<Title tag="h4" text="add module" />
+#### Options
 
-The `add module` command allows you to add modules to an existing package. When executed, it allows you to define the module's characteristics through the interactive console.
+-   `Package Type`: Choose between `web`, `backend`, `web-backend`, `node`, `express`. For a deeper understanding of the
+    different project types, consult the <Link href="/packages/create"> 'Package Creation' </Link> section.
+
+<Title tag="h4" text="beyond add module" />
 
 <Code>{`beyond add module [subpath]`}</Code>
 
-<Title tag="h4" text="--version" />
+#### Description
 
-Allows you to check the version of <BeyondJS /> installed.
+The `beyond add module` command allows the addition of modules to an existing package. Upon executing this command, an
+interactive console is activated to define the module's characteristics.
+
+<Title tag="h4" text="beyond --version" />
 
 <Code>{`beyond --version`}</Code>
 
-<NextLinks items={['frontend/intro', 'backend']} />
+#### Description
+
+This command facilitates the verification of the installed BeyondJS version. It returns the version number, helping you
+manage your environment effectively.
+
+<Title tag="h4" text="beyond build" />
+
+<Code>{`beyond build --pkg=[packageName] --distribution=[yourDistribution] --logs=[boolean]`}</Code>
+
+#### Description
+
+The `beyond build` command allows for the compilation of a specified project distribution. This is particularly useful
+for preparing your project for a production environment. Upon execution, the command will build the project based on the
+parameters provided and output logs based on your preference.
+
+#### Parameters
+
+-   `--pkg`: Required. Defines the identifier of the package that will be compiled. For instance, if your package is
+    named "@my/package", that would be the value you specify here.
+
+-   `--distribution`: Required. Specifies the type of distribution you are building, such as `web`, `backend`, etc. This
+    parameter informs BeyondJS about the context in which the project should operate.
+
+-   `--logs`: Optional. A boolean flag to toggle the verbosity of the build logs. If set to `true`, detailed logs will
+    be shown in the console. If set to `false` or omitted, only essential information will be displayed.
+
+#### Example Usage
+
+To build a web distribution of a package named "@my/package" and view detailed logs:
+
+<Code>{`beyond build --pkg=@my/package --distribution=web --logs=true`}</Code>
+
+<NextLinks items={['widgets', 'backend']} />

--- a/documentation/modules/contents/languages/es/mdx/starting/cli.mdx
+++ b/documentation/modules/contents/languages/es/mdx/starting/cli.mdx
@@ -1,57 +1,94 @@
-import {
-	Link,
-	ELink,
-	DocHeader,
-	Title,
-	Subtitle,
-	BeyondJS,
-	NextLinks,
-} from '@beyond/docs/components/html';
+import { Link, DocHeader, Title, Subtitle, BeyondJS, NextLinks } from '@beyond/docs/components/html';
 import { Code } from '@beyond/docs/code';
 
-<DocHeader pretitle="Fundamentos" title="BeyondJS Cli" />
+<DocHeader pretitle="Fundamentos" title="BeyondJS CLI: Guía Exhaustiva de Comandos" />
 
-BeyondJS provee la siguiente lista de comandos para trabajar desde la consola de tu preferencia:
+## Introducción
 
-> Se recomienda el uso del git bash en una versioan mayor a la `5.1.16` o en su defecto el bash que provea su
-> editor de codigo favorito, en este tutorial se uso el bash que provee vscode (En caso de no tenerlo configurado consulte <ELink href="https://stackoverflow.com/questions/65438333/how-to-add-git-bash-to-vscode">este link</ELink>)
+BeyondJS ofrece un robusto conjunto de instrucciones de línea de comandos diseñadas para agilizar tu proceso de
+desarrollo. Esta guía elabora la funcionalidad, el uso y los parámetros que cada comando acepta. Comprender estos
+comandos es crucial para trabajar de manera eficiente con BeyondJS.
 
-<Title tag="h4" text="run" />
+## Resumen de Comandos
 
-<Code>{`beyond run [--workspace port]`}</Code>
+<Title tag="h4" text="beyond run" />
 
-El comando `run` inicializa el DevServer de <BeyondJS/> y habilita la conexión con
-el <Link href="/workspace">BeyondJS Workspace</Link>, lo que facilita el proceso de depuración y gestión de paquetes.
-Es necesario ejecutarlo para comenzar a trabajar con <BeyondJS/>.
+<Code>{`beyond run [--inspector puerto]`}</Code>
 
-##### Parametros:
+#### Descripción
 
--   --workspace: Es opcional. Este parametro define el puerto de conexión websocket para que el
-    <Link href="/workspace"> Workspace</Link> pueda obtener información acerca de los paquetes disponibles
-    en el DevServer. sino es pasado, <BeyondJS /> tomará por defecto el puerto 4000.
+El comando `beyond run` inicializa el Servidor de Desarrollo de BeyondJS (DevServer) y establece una conexión con el
 
-<Title tag="h4" text="add package" />
+<Link href="/workspace"> Espacio de Trabajo de BeyondJS</Link>. Esta integración simplifica las operaciones de
+depuración y gestión de paquetes, lo que lo convierte en un comando esencial para iniciar tu trabajo con BeyondJS.
+
+#### Parámetros
+
+-   `--inspector`: Opcional. Especifica el puerto WebSocket para que el <Link href="/workspace">Espacio de
+    Trabajo</Link> pueda obtener información sobre los paquetes disponibles en el DevServer. Si se omite este parámetro,
+    el puerto por defecto será 4000.
+
+<Title tag="h4" text="beyond add package" />
 
 <Code>{`beyond add package`}</Code>
 
-"El comando add package permite crear un nuevo paquete y agregarlo al DevServer.
-Al ejecutarlo, se abre una consola interactiva donde se pueden definir las características del paquete, como por ejemplo:
+#### Descripción
 
--   Tipo de paquete: se puede elegir entre las opciones web, backend, web-backend, node, express.
-    Para obtener más información sobre los diferentes tipos de proyectos, consulta la
-    sección <Link href="/packages/create">creación de paquetes</Link>."
+El comando `beyond add package` te permite crear un nuevo paquete e integrarlo en el DevServer. Al ejecutarlo, se activa
+una consola interactiva que te invita a especificar varios atributos del paquete.
 
-<Title tag="h4" text="add module" />
+#### Opciones
 
-El comando `add module` permite agregar módulos a un paquete existente. Al ejecutarlo permite definir las caracteristicas
-del mismo por medio de la consola interactiva.
+-   `Tipo de Paquete`: Selecciona entre `web`, `backend`, `web-backend`, `node`, `express`. Para un entendimiento
+    profundo de los diferentes tipos de proyectos, consulta la sección <Link href="/packages/create">'Creación de
+    Paquetes'</Link>.
 
-<Code>{`beyond add module [subpath]`}</Code>
+<Title tag="h4" text="beyond add module" />
 
-<Title tag="h4" text="--version" />
+<Code>{`beyond add module [subruta]`}</Code>
 
-Permite verificar la versión de <BeyondJS /> instalada.
+#### Descripción
+
+El comando `beyond add module` permite la adición de módulos a un paquete existente. Al ejecutar este comando, se activa
+una consola interactiva para definir las características del módulo.
+
+<Title tag="h4" text="beyond --version" />
 
 <Code>{`beyond --version`}</Code>
+
+#### Descripción
+
+Este comando facilita la verificación de la versión de BeyondJS instalada. Devuelve el número de versión, ayudándote a
+gestionar tu entorno de manera efectiva.
+
+<Title tag="h4" text="beyond build" />
+
+<Code>{`beyond build --pkg=[nombreDelPaquete] --distribution=[tuDistribución] --logs=[booleano]`}</Code>
+
+#### Descripción
+
+El comando `beyond build` permite la compilación de un proyecto para una distribución específica. Esto es
+particularmente útil para preparar tu proyecto para un entorno de producción. Al ejecutarse, el comando compilará el
+proyecto basándose en los parámetros proporcionados y generará registros según tu preferencia.
+
+#### Parámetros
+
+-   `--pkg`: Obligatorio. Define el identificador del paquete que será compilado. Por ejemplo, si tu paquete se llama
+    "@mi/paquete", ese sería el valor que especificarías aquí.
+
+-   `--distribution`: Obligatorio. Especifica el tipo de distribución que estás construyendo, como `web`, `backend`,
+    etc. Este parámetro informa a BeyondJS sobre el contexto en el que el proyecto debe operar.
+
+-   `--logs`: Opcional. Un indicador booleano para activar o desactivar la verbosidad de los registros de construcción.
+    Si se configura como `true`, se mostrarán registros detallados en la consola. Si se configura como `false` o se
+    omite, solo se mostrará información esencial.
+
+#### Uso de Ejemplo
+
+Para compilar una distribución web de un paquete llamado "@mi/paquete" y ver registros detallados:
+
+<Code>{`beyond build --pkg=@mi/paquete --distribution=web --logs=true`}</Code>
+
+<NextLinks items={['funciones-avanzadas', 'depuración']} />
 
 <NextLinks items={['widgets', 'backend']} />

--- a/projects.json
+++ b/projects.json
@@ -1,6 +1,1 @@
-[
-  "/b-ui/project.json",
-  "/documentation/project.json",
-  "/borrar/project.json",
-  "/beyond-docs-components/package.json"
-]
+["/b-ui/project.json", "/documentation/project.json", "/borrar/project.json", "/beyond-docs-components/package.json"]


### PR DESCRIPTION
In Beyond v1.2.0 the beyond build command was introduced in the Command list, in this PR the command is documented in the CLI section

Also along the way we updated the applications parameter of the beyond.json file to packages so that the documentation can be run without problems in the current version of beyond, along the way we detected a bug with the under-construction and missing widgets.